### PR TITLE
HH:MM day/night schedule, notification docs, UTF-8 degree fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,140 @@
+# MQTT LED Matrix Clock (ZegarTV)
+
+An ESP8266 (Wemos D1 mini) driving a MAX72xx 4×1 LED matrix. It shows the time,
+adjusts brightness on a day/night schedule, and integrates with Home Assistant
+over MQTT with auto-discovery. Notifications, animations, OTA updates and a web
+updater are supported.
+
+## Hardware
+
+- **Board:** Wemos D1 mini (ESP8266)
+- **Display:** 4× MAX72xx 8×8 modules (32×8 px), rotation configurable
+- **Wiring:** `CLK → D5 (SCK)`, `CS → D6`, `DIN → D7 (MOSI)`
+
+## Build & flash (PlatformIO)
+
+```bash
+pio run                                   # build
+pio run -t upload --upload-port <port>    # flash over USB
+pio run -t upload --upload-port <ip>      # flash over OTA (ArduinoOTA)
+```
+
+### Secrets
+
+Credentials are kept out of source control. Copy the template and fill it in:
+
+```bash
+cp src/secrets.example.h src/secrets.h
+```
+
+`src/secrets.h` is git-ignored. It defines `SECRET_MQTT_USER`,
+`SECRET_MQTT_PASSWORD`, and `SECRET_TIMEZONE_DB_API_KEY`.
+
+Other settings (MQTT broker IP, timezone, pins, display size, default schedule
+and brightness) live in `src/Settings.h`.
+
+## First boot / Wi-Fi
+
+On first boot (or when it can't join a known network) the clock opens a
+WiFiManager config-portal access point named **"Zegar TV"**. Connect to it and
+enter your Wi-Fi credentials. If the very first connect after a flash fails,
+power-cycle the device in its normal location.
+
+## Reliability
+
+- OTA and the web updater start **before** MQTT/time, so firmware recovery is
+  always reachable even if a network service is slow or down.
+- No internet, failed time sync, or an unreachable MQTT broker never blocks the
+  device. Until the first successful time sync the display shows `--:--`.
+- If the clock drops offline, its MQTT Last Will marks it unavailable in HA.
+
+## Home Assistant
+
+The clock publishes MQTT discovery configs, so a single **"MQTT Clock"** device
+appears automatically with these entities:
+
+| Entity | Type | Purpose |
+| --- | --- | --- |
+| Clock Status | sensor | online/offline status |
+| Day/Night Mode | sensor | current mode |
+| Day Brightness | number (0–15) | brightness during the day |
+| Night Brightness | number (0–15) | brightness at night |
+| Day Start Time | time (HH:MM) | when day mode begins |
+| Night Start Time | time (HH:MM) | when night mode begins |
+| Send Notification | text | send a message (see below) |
+| Animation | select | `heart` / `wave` / `pulse` |
+
+> The **Send Notification** entity carries the notification schema (below) in
+> its **Attributes** in Home Assistant, so the usage is discoverable in-app.
+
+### Driving the schedule from the sun
+
+Because the schedule uses `time` entities, a Sun-based automation can set them:
+
+```yaml
+- alias: "Clock day mode at sunrise"
+  trigger: { platform: sun, event: sunrise }
+  action:
+    - service: time.set_value
+      target: { entity_id: time.mqtt_clock_day_start_time }
+      data: { time: "{{ now().strftime('%H:%M:%S') }}" }
+
+- alias: "Clock night mode at sunset"
+  trigger: { platform: sun, event: sunset }
+  action:
+    - service: time.set_value
+      target: { entity_id: time.mqtt_clock_night_start_time }
+      data: { time: "{{ now().strftime('%H:%M:%S') }}" }
+```
+
+## MQTT topics
+
+Base prefix: `clock/zegarTV`
+
+| Topic | Direction | Payload |
+| --- | --- | --- |
+| `clock/zegarTV/notification` | in | plain text or JSON (see below) |
+| `clock/zegarTV/notification/help` | out (retained) | usage docs (HA attributes) |
+| `clock/zegarTV/animation` | in | `heart` / `wave` / `pulse` |
+| `clock/zegarTV/brightness/day` | in | `0`–`15` |
+| `clock/zegarTV/brightness/night` | in | `0`–`15` |
+| `clock/zegarTV/schedule/day_start` | in | `HH:MM:SS` |
+| `clock/zegarTV/schedule/night_start` | in | `HH:MM:SS` |
+| `clock/zegarTV/status` | out (retained) | JSON status |
+| `clock/zegarTV/discovery` | in | any payload re-sends discovery |
+
+## Notifications
+
+Publish to `clock/zegarTV/notification`.
+
+- **Plain text** — scrolls once, e.g. `Hello`.
+- **JSON object** — any of the following fields:
+
+| Field | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `message` | string | — | required |
+| `scrolling` | bool | `true` | `false` = static, centered |
+| `speed` | int 5–100 | `35` | ms per step; lower = faster |
+| `repeat` | int 1–10 | `1` | scroll repeats |
+| `brightness` | int 0–15 or `-1` | `-1` | `-1` = keep current |
+| `flash` | bool | `false` | static messages only |
+| `flash_count` | int 1–10 | `3` | flashes when `flash` is true |
+
+Examples:
+
+```json
+{"message": "Dinner!", "speed": 15, "repeat": 2}
+{"message": "ALERT", "scrolling": false, "flash": true, "flash_count": 5, "brightness": 15}
+```
+
+Text is UTF-8 and mapped to the display's CP437 font. The degree sign `°` is
+handled automatically (e.g. `21°C` renders correctly).
+
+## Animations
+
+Publish one of `heart`, `wave`, `pulse` to `clock/zegarTV/animation`.
+
+## OTA & web updater
+
+- **ArduinoOTA** on port 8266 (PlatformIO OTA / espota).
+- **Web updater** on port 80 for uploading a firmware `.bin` from a browser.

--- a/src/DisplayManager.cpp
+++ b/src/DisplayManager.cpp
@@ -14,7 +14,7 @@ void DisplayManager::scrollMessage(const String &msg)
 
 void DisplayManager::scrollMessage(const String &msg, int speed)
 {
-  String scrollMsg = msg + " "; // add a space at the end
+  String scrollMsg = sanitizeText(msg) + " "; // add a space at the end
   for (int i = 0; i < (int)(CHAR_WIDTH * scrollMsg.length() + matrix.width() - 1 - SPACER); i++)
   {
     if (refresh == 1)
@@ -46,9 +46,10 @@ void DisplayManager::scrollMessage(const String &msg, int speed)
 
 void DisplayManager::centerPrint(const String &msg)
 {
-  int x = calculateCenterX(msg.length());
+  String text = sanitizeText(msg);
+  int x = calculateCenterX(text.length());
   matrix.setCursor(x, 0);
-  matrix.print(msg);
+  matrix.print(text);
   matrix.write();
 }
 
@@ -82,6 +83,11 @@ void DisplayManager::initializeMatrix()
   Serial.println("Number of LED Displays: " + String(NUMBER_OF_HORIZONTAL_DISPLAYS));
   matrix.setIntensity(0); // Start with brightness 0
 
+  // Use real CP437 mapping so high-range glyphs (e.g. the degree sign at
+  // 0xF8) render correctly. Without this, Adafruit GFX shifts every byte
+  // >= 0xB0 by one and prints the wrong character.
+  matrix.cp437(true);
+
   // Configure matrix panels
   int maxPos = NUMBER_OF_HORIZONTAL_DISPLAYS * NUMBER_OF_VERTICAL_DISPLAYS;
   for (int i = 0; i < maxPos; i++)
@@ -113,4 +119,34 @@ void DisplayManager::write()
 int DisplayManager::calculateCenterX(int textLength)
 {
   return (matrix.width() - (textLength * CHAR_WIDTH)) / 2;
+}
+
+String DisplayManager::sanitizeText(const String &msg)
+{
+  String out;
+  out.reserve(msg.length());
+
+  for (unsigned int i = 0; i < msg.length(); i++)
+  {
+    unsigned char c = (unsigned char)msg[i];
+
+    // UTF-8 degree sign (U+00B0) arrives as the two bytes 0xC2 0xB0.
+    if (c == 0xC2 && (i + 1) < msg.length() && (unsigned char)msg[i + 1] == 0xB0)
+    {
+      out += (char)0xF8; // CP437 degree glyph
+      i++;               // skip the trailing 0xB0
+      continue;
+    }
+
+    // Bare Latin-1 degree byte, just in case a client sends it un-encoded.
+    if (c == 0xB0)
+    {
+      out += (char)0xF8;
+      continue;
+    }
+
+    out += (char)c;
+  }
+
+  return out;
 }

--- a/src/DisplayManager.h
+++ b/src/DisplayManager.h
@@ -32,4 +32,8 @@ private:
 
   // Helper functions
   int calculateCenterX(int textLength);
+
+  // Convert UTF-8 payloads (e.g. from MQTT) into the single-byte CP437 codes
+  // the LED font uses. Currently maps the degree sign; extend as needed.
+  String sanitizeText(const String &msg);
 };

--- a/src/MQTTManager.cpp
+++ b/src/MQTTManager.cpp
@@ -8,9 +8,9 @@ MQTTManager *MQTTManager::instance = nullptr;
 MQTTManager::MQTTManager(DisplayManager &displayRef, TimeManager &timeRef)
     : display(displayRef), timeManager(timeRef), mqttClient(wifiClient),
       dayBrightness(DEFAULT_DAY_BRIGHTNESS), nightBrightness(DEFAULT_NIGHT_BRIGHTNESS),
-      dayStartHour(DEFAULT_DAY_START_HOUR), nightStartHour(DEFAULT_NIGHT_START_HOUR),
+      dayStartMinutes(DEFAULT_DAY_START_MINUTES), nightStartMinutes(DEFAULT_NIGHT_START_MINUTES),
       showingNotification(false), lastReconnectAttempt(0), reconnectAttempts(0),
-      filesystemAvailable(false)
+      lastStatusPublish(0), filesystemAvailable(false)
 {
   instance = this; // Set static reference for callback
 }
@@ -74,6 +74,14 @@ void MQTTManager::loop()
   if (!showingNotification)
   {
     updateBrightnessBasedOnTime();
+  }
+
+  // Periodically refresh status so HA sensors (Day/Night mode, etc.) stay
+  // current as the clock crosses a schedule boundary, even with no commands.
+  if (mqttClient.connected() &&
+      (millis() - lastStatusPublish >= MQTT_STATUS_PUBLISH_INTERVAL))
+  {
+    sendStatus("online");
   }
 }
 
@@ -159,12 +167,13 @@ void MQTTManager::sendStatus(const String &status)
     payload += "\"status\":\"" + status + "\",";
     payload += "\"day_brightness\":" + String(dayBrightness) + ",";
     payload += "\"night_brightness\":" + String(nightBrightness) + ",";
-    payload += "\"day_start_hour\":" + String(dayStartHour) + ",";
-    payload += "\"night_start_hour\":" + String(nightStartHour) + ",";
+    payload += "\"day_start\":\"" + minutesToTimeString(dayStartMinutes) + "\",";
+    payload += "\"night_start\":\"" + minutesToTimeString(nightStartMinutes) + "\",";
     payload += "\"is_day_time\":" + String(isDayTime() ? "true" : "false");
     payload += "}";
 
     mqttClient.publish(MQTT_TOPIC_STATUS.c_str(), payload.c_str(), true); // Retained status
+    lastStatusPublish = millis();
   }
 }
 
@@ -246,17 +255,24 @@ void MQTTManager::sendDiscoveryConfig()
 
   mqttClient.publish("homeassistant/number/mqtt_clock/night_brightness/config", night_brightness_config.c_str(), true);
 
-  // 5. Notification Text Input
+  // 5. Notification Text Input. The json_attributes_topic surfaces the usage
+  // docs (schema + examples) as entity attributes inside Home Assistant.
   String notification_config = "{"
                                "\"name\":\"Send Notification\","
                                "\"unique_id\":\"" +
                                device_id + "_notification\","
                                            "\"command_topic\":\"" +
                                MQTT_TOPIC_NOTIFICATION + "\","
-                                                         "\"icon\":\"mdi:message-text\"," +
+                                                         "\"json_attributes_topic\":\"" +
+                               MQTT_TOPIC_NOTIFICATION_HELP + "\","
+                                                              "\"icon\":\"mdi:message-text\"," +
                                device_info + "}";
 
   mqttClient.publish("homeassistant/text/mqtt_clock/notification/config", notification_config.c_str(), true);
+
+  // Publish the usage docs (retained) so they appear under the notification
+  // entity's Attributes in Home Assistant.
+  publishNotificationHelp();
 
   // 6. Animation Select (dropdown: heart / wave / pulse)
   String animation_config = "{"
@@ -271,37 +287,67 @@ void MQTTManager::sendDiscoveryConfig()
 
   mqttClient.publish("homeassistant/select/mqtt_clock/animation/config", animation_config.c_str(), true);
 
-  // 7. Day Start Hour Number Control
+  // Remove the previous hour-only "number" entities (superseded by the time
+  // entities below). Publishing an empty retained payload deletes a stale
+  // discovery config from Home Assistant.
+  mqttClient.publish("homeassistant/number/mqtt_clock/day_start/config", "", true);
+  mqttClient.publish("homeassistant/number/mqtt_clock/night_start/config", "", true);
+
+  // 7. Day Start Time (HH:MM). A Sun-based HA automation can write to this.
   String day_start_config = "{"
-                            "\"name\":\"Day Start Hour\","
+                            "\"name\":\"Day Start Time\","
                             "\"unique_id\":\"" +
-                            device_id + "_day_start\","
+                            device_id + "_day_start_time\","
                                         "\"state_topic\":\"" +
                             MQTT_TOPIC_STATUS + "\","
                                                 "\"command_topic\":\"" +
                             MQTT_TOPIC_SCHEDULE_DAY_START + "\","
-                                                           "\"value_template\":\"{{ value_json.day_start_hour }}\","
-                                                           "\"min\":0,\"max\":23,\"step\":1,"
+                                                           "\"value_template\":\"{{ value_json.day_start }}\","
                                                            "\"icon\":\"mdi:weather-sunset-up\"," +
                             device_info + "}";
 
-  mqttClient.publish("homeassistant/number/mqtt_clock/day_start/config", day_start_config.c_str(), true);
+  mqttClient.publish("homeassistant/time/mqtt_clock/day_start/config", day_start_config.c_str(), true);
 
-  // 8. Night Start Hour Number Control
+  // 8. Night Start Time (HH:MM). A Sun-based HA automation can write to this.
   String night_start_config = "{"
-                              "\"name\":\"Night Start Hour\","
+                              "\"name\":\"Night Start Time\","
                               "\"unique_id\":\"" +
-                              device_id + "_night_start\","
+                              device_id + "_night_start_time\","
                                           "\"state_topic\":\"" +
                               MQTT_TOPIC_STATUS + "\","
                                                   "\"command_topic\":\"" +
                               MQTT_TOPIC_SCHEDULE_NIGHT_START + "\","
-                                                               "\"value_template\":\"{{ value_json.night_start_hour }}\","
-                                                               "\"min\":0,\"max\":23,\"step\":1,"
+                                                               "\"value_template\":\"{{ value_json.night_start }}\","
                                                                "\"icon\":\"mdi:weather-sunset-down\"," +
                               device_info + "}";
 
-  mqttClient.publish("homeassistant/number/mqtt_clock/night_start/config", night_start_config.c_str(), true);
+  mqttClient.publish("homeassistant/time/mqtt_clock/night_start/config", night_start_config.c_str(), true);
+}
+
+void MQTTManager::publishNotificationHelp()
+{
+  if (!mqttClient.connected())
+  {
+    return;
+  }
+
+  // Each key becomes an attribute on the "Send Notification" entity in HA.
+  // Keep this compact so the whole packet stays within MQTT_BUFFER_SIZE.
+  String help = "{"
+                "\"usage\":\"Publish plain text (scrolls once) or a JSON object\","
+                "\"message\":\"string, required\","
+                "\"scrolling\":\"bool, default true; false = static/centered\","
+                "\"speed\":\"int 5-100 ms, default 35; lower = faster\","
+                "\"repeat\":\"int 1-10, default 1\","
+                "\"brightness\":\"int 0-15 or -1, default -1 (keep current)\","
+                "\"flash\":\"bool, default false (static only)\","
+                "\"flash_count\":\"int 1-10, default 3\","
+                "\"example\":\"{\\\"message\\\":\\\"Dinner!\\\",\\\"speed\\\":15,\\\"repeat\\\":2}\","
+                "\"animation\":\"publish heart|wave|pulse to " +
+                MQTT_TOPIC_ANIMATION + "\""
+                                       "}";
+
+  mqttClient.publish(MQTT_TOPIC_NOTIFICATION_HELP.c_str(), help.c_str(), true);
 }
 
 void MQTTManager::mqttCallback(char *topic, byte *payload, unsigned int length)
@@ -354,18 +400,18 @@ void MQTTManager::handleMessage(const String &topic, const String &message)
   }
   else if (topic == MQTT_TOPIC_SCHEDULE_DAY_START)
   {
-    int hour = message.toInt();
-    if (hour >= 0 && hour <= 23)
+    int minutes = parseTimeStringToMinutes(message);
+    if (minutes >= 0)
     {
-      setDayStartHour(hour);
+      setDayStartMinutes(minutes);
     }
   }
   else if (topic == MQTT_TOPIC_SCHEDULE_NIGHT_START)
   {
-    int hour = message.toInt();
-    if (hour >= 0 && hour <= 23)
+    int minutes = parseTimeStringToMinutes(message);
+    if (minutes >= 0)
     {
-      setNightStartHour(hour);
+      setNightStartMinutes(minutes);
     }
   }
   else if (topic == MQTT_TOPIC_PREFIX + "/discovery")
@@ -406,18 +452,49 @@ void MQTTManager::setNightBrightness(int brightness)
   saveSettings();
 }
 
-void MQTTManager::setDayStartHour(int hour)
+void MQTTManager::setDayStartMinutes(int minutes)
 {
-  dayStartHour = constrain(hour, 0, 23);
+  dayStartMinutes = constrain(minutes, 0, 1439);
   updateBrightnessBasedOnTime();
   saveSettings();
 }
 
-void MQTTManager::setNightStartHour(int hour)
+void MQTTManager::setNightStartMinutes(int minutes)
 {
-  nightStartHour = constrain(hour, 0, 23);
+  nightStartMinutes = constrain(minutes, 0, 1439);
   updateBrightnessBasedOnTime();
   saveSettings();
+}
+
+String MQTTManager::minutesToTimeString(int minutes)
+{
+  minutes = constrain(minutes, 0, 1439);
+  char buffer[9];
+  snprintf(buffer, sizeof(buffer), "%02d:%02d:00", minutes / 60, minutes % 60);
+  return String(buffer);
+}
+
+int MQTTManager::parseTimeStringToMinutes(const String &value)
+{
+  int firstColon = value.indexOf(':');
+  if (firstColon < 0)
+  {
+    return -1;
+  }
+
+  int parsedHour = value.substring(0, firstColon).toInt();
+
+  int secondColon = value.indexOf(':', firstColon + 1);
+  int parsedMinute = (secondColon < 0)
+                         ? value.substring(firstColon + 1).toInt()
+                         : value.substring(firstColon + 1, secondColon).toInt();
+
+  if (parsedHour < 0 || parsedHour > 23 || parsedMinute < 0 || parsedMinute > 59)
+  {
+    return -1;
+  }
+
+  return parsedHour * 60 + parsedMinute;
 }
 
 void MQTTManager::updateBrightnessBasedOnTime()
@@ -428,17 +505,17 @@ void MQTTManager::updateBrightnessBasedOnTime()
 
 bool MQTTManager::isDayTime()
 {
-  int currentHour = hour();
+  int currentMinutes = hour() * 60 + minute();
 
   // Handle normal case (day start < night start)
-  if (dayStartHour < nightStartHour)
+  if (dayStartMinutes < nightStartMinutes)
   {
-    return (currentHour >= dayStartHour && currentHour < nightStartHour);
+    return (currentMinutes >= dayStartMinutes && currentMinutes < nightStartMinutes);
   }
-  // Handle wrap-around case (night start < day start, e.g., day starts at 6, night starts at 22)
+  // Handle wrap-around case (night start < day start, e.g. day 06:30, night 22:00)
   else
   {
-    return (currentHour >= dayStartHour || currentHour < nightStartHour);
+    return (currentMinutes >= dayStartMinutes || currentMinutes < nightStartMinutes);
   }
 }
 
@@ -464,8 +541,29 @@ void MQTTManager::loadSettings()
   // Load settings with defaults if not found
   dayBrightness = doc["day_brightness"] | DEFAULT_DAY_BRIGHTNESS;
   nightBrightness = doc["night_brightness"] | DEFAULT_NIGHT_BRIGHTNESS;
-  dayStartHour = doc["day_start_hour"] | DEFAULT_DAY_START_HOUR;
-  nightStartHour = doc["night_start_hour"] | DEFAULT_NIGHT_START_HOUR;
+
+  // Prefer the new minute-based keys. Fall back to the legacy hour-only keys
+  // (from firmware before HH:MM support) so existing devices keep their schedule.
+  if (doc["day_start_minutes"].is<int>())
+  {
+    dayStartMinutes = doc["day_start_minutes"];
+  }
+  else
+  {
+    dayStartMinutes = (doc["day_start_hour"] | (DEFAULT_DAY_START_MINUTES / 60)) * 60;
+  }
+
+  if (doc["night_start_minutes"].is<int>())
+  {
+    nightStartMinutes = doc["night_start_minutes"];
+  }
+  else
+  {
+    nightStartMinutes = (doc["night_start_hour"] | (DEFAULT_NIGHT_START_MINUTES / 60)) * 60;
+  }
+
+  dayStartMinutes = constrain(dayStartMinutes, 0, 1439);
+  nightStartMinutes = constrain(nightStartMinutes, 0, 1439);
 }
 
 void MQTTManager::saveSettings()
@@ -480,8 +578,8 @@ void MQTTManager::saveSettings()
 
   doc["day_brightness"] = dayBrightness;
   doc["night_brightness"] = nightBrightness;
-  doc["day_start_hour"] = dayStartHour;
-  doc["night_start_hour"] = nightStartHour;
+  doc["day_start_minutes"] = dayStartMinutes;
+  doc["night_start_minutes"] = nightStartMinutes;
 
   File file = LittleFS.open("/clock_settings.json", "w");
   if (!file)

--- a/src/MQTTManager.h
+++ b/src/MQTTManager.h
@@ -27,6 +27,7 @@ const int MQTT_MAX_RECONNECT_ATTEMPTS = 3;          // Max attempts before yield
 const int MQTT_BUFFER_SIZE = 1024;                  // MQTT buffer size for discovery messages
 const int MQTT_CONNECT_TIMEOUT_MS = 3000;           // Max blocking time for TCP connect (ms)
 const uint16_t MQTT_SOCKET_TIMEOUT_S = 3;           // Max blocking time for MQTT handshake/reads (s)
+const unsigned long MQTT_STATUS_PUBLISH_INTERVAL = 60000UL; // Periodic status refresh (ms)
 
 class MQTTManager
 {
@@ -43,19 +44,20 @@ public:
   // Message handling
   void sendStatus(const String &status);
   void sendDiscoveryConfig();
+  void publishNotificationHelp(); // Retained usage docs shown as HA attributes
 
   // Brightness management
   void setDayBrightness(int brightness);
   void setNightBrightness(int brightness);
-  void setDayStartHour(int hour);
-  void setNightStartHour(int hour);
+  void setDayStartMinutes(int minutes);
+  void setNightStartMinutes(int minutes);
   void updateBrightnessBasedOnTime();
 
   // Getters for current settings
   int getDayBrightness() const { return dayBrightness; }
   int getNightBrightness() const { return nightBrightness; }
-  int getDayStartHour() const { return dayStartHour; }
-  int getNightStartHour() const { return nightStartHour; }
+  int getDayStartMinutes() const { return dayStartMinutes; }
+  int getNightStartMinutes() const { return nightStartMinutes; }
   bool isShowingNotification() const { return showingNotification; }
 
 private:
@@ -67,8 +69,9 @@ private:
   // Brightness settings
   int dayBrightness;
   int nightBrightness;
-  int dayStartHour;
-  int nightStartHour;
+  // Schedule stored as minutes-since-midnight (0-1439) for HH:MM granularity.
+  int dayStartMinutes;
+  int nightStartMinutes;
 
   // Notification handling
   String currentNotification;
@@ -87,9 +90,17 @@ private:
   void playAnimation(const String &animationType);
   bool isDayTime();
 
+  // Time-of-day helpers for HH:MM schedule handling
+  static String minutesToTimeString(int minutes);      // e.g. 420 -> "07:00:00"
+  static int parseTimeStringToMinutes(const String &value); // "HH:MM[:SS]" -> minutes, -1 if invalid
+
   // Reconnection tracking
   unsigned long lastReconnectAttempt;
   int reconnectAttempts;
+
+  // Periodic status refresh so HA sensors (e.g. Day/Night mode) stay current
+  // even when no command arrives.
+  unsigned long lastStatusPublish;
 
   // Filesystem status
   bool filesystemAvailable;

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -54,6 +54,7 @@ const String MQTT_TOPIC_PREFIX = "clock/zegarTV";
 
 // MQTT Topics
 const String MQTT_TOPIC_NOTIFICATION = MQTT_TOPIC_PREFIX + "/notification";
+const String MQTT_TOPIC_NOTIFICATION_HELP = MQTT_TOPIC_PREFIX + "/notification/help"; // Retained usage docs (HA attributes)
 const String MQTT_TOPIC_ANIMATION = MQTT_TOPIC_PREFIX + "/animation";
 const String MQTT_TOPIC_BRIGHTNESS_DAY = MQTT_TOPIC_PREFIX + "/brightness/day";
 const String MQTT_TOPIC_BRIGHTNESS_NIGHT = MQTT_TOPIC_PREFIX + "/brightness/night";
@@ -62,7 +63,10 @@ const String MQTT_TOPIC_SCHEDULE_NIGHT_START = MQTT_TOPIC_PREFIX + "/schedule/ni
 const String MQTT_TOPIC_STATUS = MQTT_TOPIC_PREFIX + "/status";
 
 // Brightness Settings
-const int DEFAULT_DAY_BRIGHTNESS = 8;    // Default day brightness (0-15)
-const int DEFAULT_NIGHT_BRIGHTNESS = 1;  // Default night brightness (0-15)
-const int DEFAULT_DAY_START_HOUR = 7;    // Default day mode start hour (24h format)
-const int DEFAULT_NIGHT_START_HOUR = 22; // Default night mode start hour (24h format)
+const int DEFAULT_DAY_BRIGHTNESS = 8;   // Default day brightness (0-15)
+const int DEFAULT_NIGHT_BRIGHTNESS = 1; // Default night brightness (0-15)
+// Day/Night schedule is stored as minutes-since-midnight (0-1439) so it can be
+// set to any HH:MM, not just whole hours. Home Assistant exposes these as
+// "time" entities that a Sun-based automation can drive automatically.
+const int DEFAULT_DAY_START_MINUTES = 7 * 60;    // 07:00
+const int DEFAULT_NIGHT_START_MINUTES = 22 * 60; // 22:00


### PR DESCRIPTION
## Summary
- **HH:MM day/night schedule**: schedule is stored as minutes-since-midnight and exposed as Home Assistant `time` entities (Day/Night Start Time), so a Sun-based automation can drive it. Existing hour-only settings migrate automatically; the old number entities are removed.
- **Periodic status**: publish status every 60s so HA sensors (e.g. Day/Night mode) stay current as the clock crosses a boundary.
- **UTF-8 degree fix**: enable CP437 font mapping and sanitize UTF-8 payloads to single-byte font codes, so `°` (and other high-range glyphs) render correctly in notifications.
- **In-app docs**: the notification schema is published (retained) and attached to the Send Notification entity via `json_attributes_topic`, so usage is discoverable in HA's Attributes.
- **README**: documents hardware/wiring, build & flash, secrets, HA entities, MQTT topics, and the full notification schema.

## Testing
- Builds clean for `d1_mini` (PlatformIO).
- Flashed to the device over USB.