### PR TITLE
Notification fade + refactors (dead code, brightness guard, discovery, cooperative servicing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,14 +117,19 @@ Publish to `clock/zegarTV/notification`.
 | `speed` | int 5–100 | `35` | ms per step; lower = faster |
 | `repeat` | int 1–10 | `1` | scroll repeats |
 | `brightness` | int 0–15 or `-1` | `-1` | `-1` = keep current |
-| `flash` | bool | `false` | static messages only |
-| `flash_count` | int 1–10 | `3` | flashes when `flash` is true |
+| `duration` | int 1–30 | `3` | static hold time (seconds) |
+| `flash` | bool | `false` | quick fade out/in before holding (static only) |
+| `flash_count` | int 1–10 | `2` | number of fade pulses when `flash` is true |
+
+For a static message, the text optionally fades out and back in `flash_count`
+times to grab attention, then holds steady at the set brightness for `duration`
+seconds.
 
 Examples:
 
 ```json
 {"message": "Dinner!", "speed": 15, "repeat": 2}
-{"message": "ALERT", "scrolling": false, "flash": true, "flash_count": 5, "brightness": 15}
+{"message": "ALERT", "scrolling": false, "flash": true, "duration": 5, "brightness": 15}
 ```
 
 Text is UTF-8 and mapped to the display's CP437 font. The degree sign `°` is

--- a/src/BackgroundService.h
+++ b/src/BackgroundService.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "Arduino.h"
+
+// Long display operations (scrolling messages, animations, static-notification
+// holds) run to completion inside loop() and would otherwise block the network
+// stack for their whole duration. These helpers let those blocking sections
+// keep the background services alive cooperatively:
+//
+//   serviceBackground() - feed the watchdog and pump OTA / web / MQTT once.
+//   serviceDelay(ms)    - like delay(ms), but services the background roughly
+//                         every few milliseconds while it waits.
+//
+// serviceBackground() is a no-op for the network services until setup() has
+// finished initializing them (guarded internally), so it is safe to call from
+// the very first boot-time scroll.
+void serviceBackground();
+void serviceDelay(unsigned long ms);

--- a/src/DisplayManager.cpp
+++ b/src/DisplayManager.cpp
@@ -1,5 +1,6 @@
 #include "DisplayManager.h"
 #include "Settings.h"
+#include "BackgroundService.h"
 
 extern int refresh; // Global refresh flag from main
 
@@ -38,8 +39,8 @@ void DisplayManager::scrollMessage(const String &msg, int speed)
       x -= CHAR_WIDTH;
     }
 
-    matrix.write(); // Send bitmap to display
-    delay(speed);   // Use custom speed parameter
+    matrix.write();       // Send bitmap to display
+    serviceDelay(speed);  // Wait per-step while keeping background services alive
   }
   matrix.setCursor(0, 0);
 }
@@ -51,6 +52,24 @@ void DisplayManager::centerPrint(const String &msg)
   matrix.setCursor(x, 0);
   matrix.print(text);
   matrix.write();
+}
+
+void DisplayManager::fadeMessage(int targetBrightness, int stepDelayMs)
+{
+  targetBrightness = constrain(targetBrightness, 0, 15);
+
+  // Fade out
+  for (int level = targetBrightness; level >= 0; level--)
+  {
+    matrix.setIntensity(level);
+    delay(stepDelayMs);
+  }
+  // Fade back in
+  for (int level = 0; level <= targetBrightness; level++)
+  {
+    matrix.setIntensity(level);
+    delay(stepDelayMs);
+  }
 }
 
 void DisplayManager::performBrightnessAnimation()

--- a/src/DisplayManager.h
+++ b/src/DisplayManager.h
@@ -12,6 +12,10 @@ public:
   void scrollMessage(const String &msg);
   void scrollMessage(const String &msg, int speed); // Overloaded version with custom speed
   void centerPrint(const String &msg);
+  // Fade the currently displayed content out (to 0) and back in (to
+  // targetBrightness), stepDelayMs per intensity step. The content is not
+  // redrawn, only the panel intensity is modulated.
+  void fadeMessage(int targetBrightness, int stepDelayMs);
   void performBrightnessAnimation();
   void showUpdateIndicator();
   void initializeMatrix();

--- a/src/MQTTManager.cpp
+++ b/src/MQTTManager.cpp
@@ -1,5 +1,6 @@
 #include "MQTTManager.h"
 #include "Settings.h"
+#include "BackgroundService.h"
 #include <TimeLib.h>
 
 // Static member initialization
@@ -82,6 +83,17 @@ void MQTTManager::loop()
       (millis() - lastStatusPublish >= MQTT_STATUS_PUBLISH_INTERVAL))
   {
     sendStatus("online");
+  }
+}
+
+void MQTTManager::keepAlive()
+{
+  // Pump only the MQTT client (keepalive + incoming). Intentionally does NOT
+  // run the notification queue or brightness logic, so it is safe to call from
+  // inside a blocking display operation without re-entering it.
+  if (mqttClient.connected())
+  {
+    mqttClient.loop();
   }
 }
 
@@ -177,6 +189,36 @@ void MQTTManager::sendStatus(const String &status)
   }
 }
 
+String MQTTManager::getDeviceId()
+{
+  String deviceId = "mqtt_clock_" + WiFi.macAddress();
+  deviceId.replace(":", "");
+  return deviceId;
+}
+
+String MQTTManager::buildDeviceInfo()
+{
+  return "\"device\":{"
+         "\"identifiers\":[\"" +
+         getDeviceId() + "\"],"
+                         "\"name\":\"MQTT Clock\","
+                         "\"model\":\"ESP8266 LED Matrix Clock\","
+                         "\"manufacturer\":\"Custom\","
+                         "\"sw_version\":\"1.0\""
+                         "}";
+}
+
+void MQTTManager::publishDiscovery(const String &component, const String &objectId, const String &fields)
+{
+  if (!mqttClient.connected())
+  {
+    return;
+  }
+  String payload = "{" + fields + "," + buildDeviceInfo() + "}";
+  String topic = "homeassistant/" + component + "/mqtt_clock/" + objectId + "/config";
+  mqttClient.publish(topic.c_str(), payload.c_str(), true);
+}
+
 void MQTTManager::sendDiscoveryConfig()
 {
   if (!mqttClient.connected())
@@ -184,108 +226,79 @@ void MQTTManager::sendDiscoveryConfig()
     return;
   }
 
-  String device_id = "mqtt_clock_" + WiFi.macAddress();
-  device_id.replace(":", "");
-
-  // Device information shared across all entities
-  String device_info = "\"device\":{"
-                       "\"identifiers\":[\"" +
-                       device_id + "\"],"
-                                   "\"name\":\"MQTT Clock\","
-                                   "\"model\":\"ESP8266 LED Matrix Clock\","
-                                   "\"manufacturer\":\"Custom\","
-                                   "\"sw_version\":\"1.0\""
-                                   "}";
+  const String id = getDeviceId();
 
   // 1. Status Sensor
-  String status_config = "{"
-                         "\"name\":\"Clock Status\","
-                         "\"unique_id\":\"" +
-                         device_id + "_status\","
-                                     "\"state_topic\":\"" +
-                         MQTT_TOPIC_STATUS + "\","
-                                             "\"value_template\":\"{{ value_json.status }}\","
-                                             "\"icon\":\"mdi:clock-digital\"," +
-                         device_info + "}";
-
-  mqttClient.publish("homeassistant/sensor/mqtt_clock/status/config", status_config.c_str(), true);
+  publishDiscovery("sensor", "status",
+                   "\"name\":\"Clock Status\","
+                   "\"unique_id\":\"" +
+                       id + "_status\","
+                            "\"state_topic\":\"" +
+                       MQTT_TOPIC_STATUS + "\","
+                                           "\"value_template\":\"{{ value_json.status }}\","
+                                           "\"icon\":\"mdi:clock-digital\"");
 
   // 2. Day/Night Mode Sensor
-  String daynight_config = "{"
-                           "\"name\":\"Day/Night Mode\","
-                           "\"unique_id\":\"" +
-                           device_id + "_daynight\","
-                                       "\"state_topic\":\"" +
-                           MQTT_TOPIC_STATUS + "\","
-                                               "\"value_template\":\"{% if value_json.is_day_time %}Day{% else %}Night{% endif %}\","
-                                               "\"icon\":\"mdi:weather-sunny\"," +
-                           device_info + "}";
-
-  mqttClient.publish("homeassistant/sensor/mqtt_clock/daynight/config", daynight_config.c_str(), true);
+  publishDiscovery("sensor", "daynight",
+                   "\"name\":\"Day/Night Mode\","
+                   "\"unique_id\":\"" +
+                       id + "_daynight\","
+                            "\"state_topic\":\"" +
+                       MQTT_TOPIC_STATUS + "\","
+                                           "\"value_template\":\"{% if value_json.is_day_time %}Day{% else %}Night{% endif %}\","
+                                           "\"icon\":\"mdi:weather-sunny\"");
 
   // 3. Day Brightness Number Control
-  String day_brightness_config = "{"
-                                 "\"name\":\"Day Brightness\","
-                                 "\"unique_id\":\"" +
-                                 device_id + "_day_brightness\","
-                                             "\"state_topic\":\"" +
-                                 MQTT_TOPIC_STATUS + "\","
-                                                     "\"command_topic\":\"" +
-                                 MQTT_TOPIC_BRIGHTNESS_DAY + "\","
-                                                             "\"value_template\":\"{{ value_json.day_brightness }}\","
-                                                             "\"min\":0,\"max\":15,\"step\":1,"
-                                                             "\"icon\":\"mdi:brightness-6\"," +
-                                 device_info + "}";
-
-  mqttClient.publish("homeassistant/number/mqtt_clock/day_brightness/config", day_brightness_config.c_str(), true);
+  publishDiscovery("number", "day_brightness",
+                   "\"name\":\"Day Brightness\","
+                   "\"unique_id\":\"" +
+                       id + "_day_brightness\","
+                            "\"state_topic\":\"" +
+                       MQTT_TOPIC_STATUS + "\","
+                                           "\"command_topic\":\"" +
+                       MQTT_TOPIC_BRIGHTNESS_DAY + "\","
+                                                   "\"value_template\":\"{{ value_json.day_brightness }}\","
+                                                   "\"min\":0,\"max\":15,\"step\":1,"
+                                                   "\"icon\":\"mdi:brightness-6\"");
 
   // 4. Night Brightness Number Control
-  String night_brightness_config = "{"
-                                   "\"name\":\"Night Brightness\","
-                                   "\"unique_id\":\"" +
-                                   device_id + "_night_brightness\","
-                                               "\"state_topic\":\"" +
-                                   MQTT_TOPIC_STATUS + "\","
-                                                       "\"command_topic\":\"" +
-                                   MQTT_TOPIC_BRIGHTNESS_NIGHT + "\","
-                                                                 "\"value_template\":\"{{ value_json.night_brightness }}\","
-                                                                 "\"min\":0,\"max\":15,\"step\":1,"
-                                                                 "\"icon\":\"mdi:brightness-3\"," +
-                                   device_info + "}";
-
-  mqttClient.publish("homeassistant/number/mqtt_clock/night_brightness/config", night_brightness_config.c_str(), true);
+  publishDiscovery("number", "night_brightness",
+                   "\"name\":\"Night Brightness\","
+                   "\"unique_id\":\"" +
+                       id + "_night_brightness\","
+                            "\"state_topic\":\"" +
+                       MQTT_TOPIC_STATUS + "\","
+                                           "\"command_topic\":\"" +
+                       MQTT_TOPIC_BRIGHTNESS_NIGHT + "\","
+                                                     "\"value_template\":\"{{ value_json.night_brightness }}\","
+                                                     "\"min\":0,\"max\":15,\"step\":1,"
+                                                     "\"icon\":\"mdi:brightness-3\"");
 
   // 5. Notification Text Input. The json_attributes_topic surfaces the usage
   // docs (schema + examples) as entity attributes inside Home Assistant.
-  String notification_config = "{"
-                               "\"name\":\"Send Notification\","
-                               "\"unique_id\":\"" +
-                               device_id + "_notification\","
-                                           "\"command_topic\":\"" +
-                               MQTT_TOPIC_NOTIFICATION + "\","
-                                                         "\"json_attributes_topic\":\"" +
-                               MQTT_TOPIC_NOTIFICATION_HELP + "\","
-                                                              "\"icon\":\"mdi:message-text\"," +
-                               device_info + "}";
-
-  mqttClient.publish("homeassistant/text/mqtt_clock/notification/config", notification_config.c_str(), true);
+  publishDiscovery("text", "notification",
+                   "\"name\":\"Send Notification\","
+                   "\"unique_id\":\"" +
+                       id + "_notification\","
+                            "\"command_topic\":\"" +
+                       MQTT_TOPIC_NOTIFICATION + "\","
+                                                 "\"json_attributes_topic\":\"" +
+                       MQTT_TOPIC_NOTIFICATION_HELP + "\","
+                                                      "\"icon\":\"mdi:message-text\"");
 
   // Publish the usage docs (retained) so they appear under the notification
   // entity's Attributes in Home Assistant.
   publishNotificationHelp();
 
   // 6. Animation Select (dropdown: heart / wave / pulse)
-  String animation_config = "{"
-                            "\"name\":\"Animation\","
-                            "\"unique_id\":\"" +
-                            device_id + "_animation\","
-                                        "\"command_topic\":\"" +
-                            MQTT_TOPIC_ANIMATION + "\","
-                                                   "\"options\":[\"heart\",\"wave\",\"pulse\"],"
-                                                   "\"icon\":\"mdi:animation-play\"," +
-                            device_info + "}";
-
-  mqttClient.publish("homeassistant/select/mqtt_clock/animation/config", animation_config.c_str(), true);
+  publishDiscovery("select", "animation",
+                   "\"name\":\"Animation\","
+                   "\"unique_id\":\"" +
+                       id + "_animation\","
+                            "\"command_topic\":\"" +
+                       MQTT_TOPIC_ANIMATION + "\","
+                                              "\"options\":[\"heart\",\"wave\",\"pulse\"],"
+                                              "\"icon\":\"mdi:animation-play\"");
 
   // Remove the previous hour-only "number" entities (superseded by the time
   // entities below). Publishing an empty retained payload deletes a stale
@@ -294,34 +307,28 @@ void MQTTManager::sendDiscoveryConfig()
   mqttClient.publish("homeassistant/number/mqtt_clock/night_start/config", "", true);
 
   // 7. Day Start Time (HH:MM). A Sun-based HA automation can write to this.
-  String day_start_config = "{"
-                            "\"name\":\"Day Start Time\","
-                            "\"unique_id\":\"" +
-                            device_id + "_day_start_time\","
-                                        "\"state_topic\":\"" +
-                            MQTT_TOPIC_STATUS + "\","
-                                                "\"command_topic\":\"" +
-                            MQTT_TOPIC_SCHEDULE_DAY_START + "\","
-                                                           "\"value_template\":\"{{ value_json.day_start }}\","
-                                                           "\"icon\":\"mdi:weather-sunset-up\"," +
-                            device_info + "}";
-
-  mqttClient.publish("homeassistant/time/mqtt_clock/day_start/config", day_start_config.c_str(), true);
+  publishDiscovery("time", "day_start",
+                   "\"name\":\"Day Start Time\","
+                   "\"unique_id\":\"" +
+                       id + "_day_start_time\","
+                            "\"state_topic\":\"" +
+                       MQTT_TOPIC_STATUS + "\","
+                                           "\"command_topic\":\"" +
+                       MQTT_TOPIC_SCHEDULE_DAY_START + "\","
+                                                      "\"value_template\":\"{{ value_json.day_start }}\","
+                                                      "\"icon\":\"mdi:weather-sunset-up\"");
 
   // 8. Night Start Time (HH:MM). A Sun-based HA automation can write to this.
-  String night_start_config = "{"
-                              "\"name\":\"Night Start Time\","
-                              "\"unique_id\":\"" +
-                              device_id + "_night_start_time\","
-                                          "\"state_topic\":\"" +
-                              MQTT_TOPIC_STATUS + "\","
-                                                  "\"command_topic\":\"" +
-                              MQTT_TOPIC_SCHEDULE_NIGHT_START + "\","
-                                                               "\"value_template\":\"{{ value_json.night_start }}\","
-                                                               "\"icon\":\"mdi:weather-sunset-down\"," +
-                              device_info + "}";
-
-  mqttClient.publish("homeassistant/time/mqtt_clock/night_start/config", night_start_config.c_str(), true);
+  publishDiscovery("time", "night_start",
+                   "\"name\":\"Night Start Time\","
+                   "\"unique_id\":\"" +
+                       id + "_night_start_time\","
+                            "\"state_topic\":\"" +
+                       MQTT_TOPIC_STATUS + "\","
+                                           "\"command_topic\":\"" +
+                       MQTT_TOPIC_SCHEDULE_NIGHT_START + "\","
+                                                        "\"value_template\":\"{{ value_json.night_start }}\","
+                                                        "\"icon\":\"mdi:weather-sunset-down\"");
 }
 
 void MQTTManager::publishNotificationHelp()
@@ -340,9 +347,10 @@ void MQTTManager::publishNotificationHelp()
                 "\"speed\":\"int 5-100 ms, default 35; lower = faster\","
                 "\"repeat\":\"int 1-10, default 1\","
                 "\"brightness\":\"int 0-15 or -1, default -1 (keep current)\","
-                "\"flash\":\"bool, default false (static only)\","
-                "\"flash_count\":\"int 1-10, default 3\","
-                "\"example\":\"{\\\"message\\\":\\\"Dinner!\\\",\\\"speed\\\":15,\\\"repeat\\\":2}\","
+                "\"duration\":\"int 1-30 s, default 3; static hold time\","
+                "\"flash\":\"bool, default false; quick fade out/in before holding (static only)\","
+                "\"flash_count\":\"int 1-10, default 2; number of fade pulses\","
+                "\"example\":\"{\\\"message\\\":\\\"Dinner!\\\",\\\"scrolling\\\":false,\\\"flash\\\":true}\","
                 "\"animation\":\"publish heart|wave|pulse to " +
                 MQTT_TOPIC_ANIMATION + "\""
                                        "}";
@@ -497,10 +505,21 @@ int MQTTManager::parseTimeStringToMinutes(const String &value)
   return parsedHour * 60 + parsedMinute;
 }
 
+int MQTTManager::currentAutoBrightness()
+{
+  // Before the first successful time sync, hour()/minute() read 00:00, which
+  // would wrongly select night mode and blank the display. Until we actually
+  // know the time, use the (brighter, always-visible) day brightness.
+  if (!timeManager.isTimeSynced())
+  {
+    return dayBrightness;
+  }
+  return isDayTime() ? dayBrightness : nightBrightness;
+}
+
 void MQTTManager::updateBrightnessBasedOnTime()
 {
-  int targetBrightness = isDayTime() ? dayBrightness : nightBrightness;
-  display.setIntensity(targetBrightness);
+  display.setIntensity(currentAutoBrightness());
 }
 
 bool MQTTManager::isDayTime()
@@ -621,7 +640,7 @@ void MQTTManager::showAdvancedNotification(const NotificationConfig &config)
     {
       display.scrollMessage(config.message, config.scrollSpeed);
       if (i < config.scrollRepeat - 1)
-        delay(500); // Brief pause between repeats
+        serviceDelay(500); // Brief pause between repeats
     }
 
     showingNotification = false;
@@ -629,23 +648,28 @@ void MQTTManager::showAdvancedNotification(const NotificationConfig &config)
   }
   else
   {
-    // Static notification
+    // Static notification. The brightness to settle at once done.
+    int holdBrightness = (config.brightness >= 0) ? config.brightness : currentAutoBrightness();
+
+    // Draw the message once; the fade only modulates panel intensity, so the
+    // text stays on screen throughout.
     display.fillScreen(LOW);
     display.centerPrint(config.message);
+    display.setIntensity(holdBrightness);
 
+    // Optionally fade the message out and back in a few times to grab
+    // attention, then hold it steady for the configured duration.
     if (config.flashEffect)
     {
-      Serial.println("Performing brightness animation " + String(config.flashCount) + " times");
       for (int i = 0; i < config.flashCount; i++)
       {
-        display.performBrightnessAnimation();
+        display.fadeMessage(holdBrightness, NOTIFICATION_FADE_STEP_MS);
       }
     }
-    else
-    {
-      // No flash effect - show message for 3 seconds
-      delay(3000);
-    }
+
+    // Hold the message steady at the set brightness.
+    display.setIntensity(holdBrightness);
+    serviceDelay((unsigned long)config.holdSeconds * 1000UL);
 
     // Static notification is done, return to clock
     showingNotification = false;
@@ -676,7 +700,8 @@ void MQTTManager::parseNotificationJson(const String &jsonString)
   config.scrollSpeed = constrain(doc["speed"] | 35, 5, 100);
   config.brightness = constrain(doc["brightness"] | -1, -1, 15);
   config.flashEffect = doc["flash"] | false;
-  config.flashCount = constrain(doc["flash_count"] | 3, 1, 10);
+  config.flashCount = constrain(doc["flash_count"] | 2, 1, 10);
+  config.holdSeconds = constrain(doc["duration"] | 3, 1, 30);
   config.isSimpleMessage = false;
 
   queueNotification(config);
@@ -742,7 +767,7 @@ void MQTTManager::playAnimation(const String &animationType)
       matrix.drawPixel(17, 5, HIGH);
       matrix.drawPixel(16, 6, HIGH);
       display.write();
-      delay(500);
+      serviceDelay(500);
 
       // Large heart
       display.fillScreen(LOW);
@@ -765,7 +790,7 @@ void MQTTManager::playAnimation(const String &animationType)
       matrix.drawPixel(17, 6, HIGH);
       matrix.drawPixel(16, 7, HIGH);
       display.write();
-      delay(500);
+      serviceDelay(500);
     }
   }
   else if (animationType == "wave")
@@ -784,7 +809,7 @@ void MQTTManager::playAnimation(const String &animationType)
         }
       }
       display.write();
-      delay(80);
+      serviceDelay(80);
     }
   }
   else if (animationType == "pulse")
@@ -810,7 +835,7 @@ void MQTTManager::playAnimation(const String &animationType)
         }
       }
       display.write();
-      delay(200);
+      serviceDelay(200);
     }
 
     // Contract back to center
@@ -829,7 +854,7 @@ void MQTTManager::playAnimation(const String &animationType)
         }
       }
       display.write();
-      delay(200);
+      serviceDelay(200);
     }
   }
   else
@@ -838,9 +863,9 @@ void MQTTManager::playAnimation(const String &animationType)
     for (int i = 0; i < 3; i++)
     {
       display.fillScreen(HIGH);
-      delay(200);
+      serviceDelay(200);
       display.fillScreen(LOW);
-      delay(200);
+      serviceDelay(200);
     }
   }
 

--- a/src/MQTTManager.h
+++ b/src/MQTTManager.h
@@ -16,18 +16,19 @@ struct NotificationConfig
   int scrollRepeat = 1;         // how many times to scroll (1-10)
   int scrollSpeed = 35;         // scroll speed in ms (5-100)
   int brightness = -1;          // notification brightness (-1 = use current, 0-15)
-  bool flashEffect = false;     // flash brightness effect (only for static)
-  int flashCount = 3;           // number of flashes (1-10)
+  bool flashEffect = false;     // quick fade out/in before holding (static messages only)
+  int flashCount = 2;           // number of fade pulses (1-10)
+  int holdSeconds = 3;          // how long static text stays on screen (1-30 s)
   bool isSimpleMessage = false; // true if this is a simple string message
 };
 
 // Timing constants
 const unsigned long MQTT_RECONNECT_INTERVAL = 5000; // Time between reconnect attempts (ms)
-const int MQTT_MAX_RECONNECT_ATTEMPTS = 3;          // Max attempts before yielding to loop
 const int MQTT_BUFFER_SIZE = 1024;                  // MQTT buffer size for discovery messages
 const int MQTT_CONNECT_TIMEOUT_MS = 3000;           // Max blocking time for TCP connect (ms)
 const uint16_t MQTT_SOCKET_TIMEOUT_S = 3;           // Max blocking time for MQTT handshake/reads (s)
 const unsigned long MQTT_STATUS_PUBLISH_INTERVAL = 60000UL; // Periodic status refresh (ms)
+const int NOTIFICATION_FADE_STEP_MS = 25;                   // Per-step delay of the static-notification fade pulse (ms)
 
 class MQTTManager
 {
@@ -37,6 +38,7 @@ public:
   // MQTT operations
   void initialize();
   void loop();
+  void keepAlive(); // Pump the MQTT client only (safe to call mid-display)
   bool tryReconnect(); // Non-blocking reconnect attempt
   bool isConnected();
   bool isFilesystemAvailable() const { return filesystemAvailable; }
@@ -52,6 +54,7 @@ public:
   void setDayStartMinutes(int minutes);
   void setNightStartMinutes(int minutes);
   void updateBrightnessBasedOnTime();
+  int currentAutoBrightness(); // Day or night brightness for the current time
 
   // Getters for current settings
   int getDayBrightness() const { return dayBrightness; }
@@ -78,6 +81,13 @@ private:
   bool showingNotification;
   std::queue<NotificationConfig> notificationQueue;
   NotificationConfig currentConfig;
+
+  // Discovery helpers
+  String getDeviceId();     // Stable per-device id derived from the MAC
+  String buildDeviceInfo(); // Shared "device" JSON block for every entity
+  // Publish one retained discovery config. `fields` is the entity-specific JSON
+  // body (no braces); this wraps it with the shared device block and topic.
+  void publishDiscovery(const String &component, const String &objectId, const String &fields);
 
   // Helper functions
   static void mqttCallback(char *topic, byte *payload, unsigned int length);

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -40,6 +40,9 @@ const int LED_ROTATION = 3;
 
 // Network Settings
 const String DEVICE_HOSTNAME = "ZegarTV";
+// SSID of the WiFiManager configuration portal shown on first boot / when it
+// cannot join a known network.
+const String WIFI_PORTAL_AP_NAME = "Zegar TV";
 
 // MQTT Settings
 // Use the broker's IP rather than a bare hostname: the ESP8266's DNS resolver

--- a/src/TimeDB.h
+++ b/src/TimeDB.h
@@ -32,15 +32,11 @@ class TimeDB
 public:
   TimeDB(String apiKey);
   time_t getTime();
-  String getDayName();
-  String getMonthName();
-  String getAmPm();
   String zeroPad(int number);
 
 private:
   const char *servername = "api.timezonedb.com";
   String apiKey;
-  long localMillisAtUpdate;
 
   // Constants
   static const int INVALID_TIME = 20;

--- a/src/TimeManager.cpp
+++ b/src/TimeManager.cpp
@@ -4,7 +4,7 @@
 
 TimeManager::TimeManager(TimeDB &timeDBRef, DisplayManager &displayRef)
     : timeDB(timeDBRef), display(displayRef), lastMinute("xx"), lastEpoch(0), firstEpoch(0),
-      timeoutCount(0), timeSynced(false), lastSyncAttemptMs(0)
+      timeSynced(false), lastSyncAttemptMs(0)
 {
 }
 

--- a/src/TimeManager.h
+++ b/src/TimeManager.h
@@ -37,7 +37,6 @@ private:
   String lastMinute;
   long lastEpoch;
   long firstEpoch;
-  int timeoutCount;
 
   // Sync state
   bool timeSynced;                  // true once we have a valid time at least once

--- a/src/WebOTAManager.cpp
+++ b/src/WebOTAManager.cpp
@@ -118,10 +118,20 @@ String WebOTAManager::getIndexHTML()
 
         <div class="card">
             <h3>📋 MQTT Topics</h3>
-            <p><strong>Notifications:</strong> <code>clock/zegarTV/notification</code></p>
-            <p><strong>Day Brightness:</strong> <code>clock/zegarTV/brightness/day</code></p>
-            <p><strong>Night Brightness:</strong> <code>clock/zegarTV/brightness/night</code></p>
-            <p><strong>Status:</strong> <code>clock/zegarTV/status</code></p>
+            <p><strong>Notifications:</strong> <code>)" +
+                MQTT_TOPIC_NOTIFICATION + R"(</code></p>
+            <p><strong>Animation:</strong> <code>)" +
+                MQTT_TOPIC_ANIMATION + R"(</code></p>
+            <p><strong>Day Brightness:</strong> <code>)" +
+                MQTT_TOPIC_BRIGHTNESS_DAY + R"(</code></p>
+            <p><strong>Night Brightness:</strong> <code>)" +
+                MQTT_TOPIC_BRIGHTNESS_NIGHT + R"(</code></p>
+            <p><strong>Day Start:</strong> <code>)" +
+                MQTT_TOPIC_SCHEDULE_DAY_START + R"(</code></p>
+            <p><strong>Night Start:</strong> <code>)" +
+                MQTT_TOPIC_SCHEDULE_NIGHT_START + R"(</code></p>
+            <p><strong>Status:</strong> <code>)" +
+                MQTT_TOPIC_STATUS + R"(</code></p>
         </div>
     </div>
 </body>

--- a/src/WiFiSetup.cpp
+++ b/src/WiFiSetup.cpp
@@ -15,8 +15,7 @@ void WiFiSetup::initialize()
   WiFiManager wifiManager;
   wifiManager.setAPCallback(configModeCallback);
 
-  String hostname = "Zegar TV";
-  if (!wifiManager.autoConnect(hostname.c_str()))
+  if (!wifiManager.autoConnect(WIFI_PORTAL_AP_NAME.c_str()))
   {
     Serial.println("Failed to connect to WiFi, restarting...");
     delay(3000);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "MQTTManager.h"
 #include "OTAManager.h"
 #include "WebOTAManager.h"
+#include "BackgroundService.h"
 #include <Ticker.h>
 
 // Timing constants
@@ -17,6 +18,10 @@ int refresh = 0; // Used by DisplayManager to signal scroll refresh
 Max72xxPanel matrix = Max72xxPanel(PIN_CS, NUMBER_OF_HORIZONTAL_DISPLAYS, NUMBER_OF_VERTICAL_DISPLAYS);
 unsigned long lastWiFiCheck = 0;
 
+// Set once setup() has initialized OTA/web/MQTT. Until then serviceBackground()
+// only feeds the watchdog, so boot-time scrolls never touch an unstarted service.
+bool servicesReady = false;
+
 // Core components
 TimeDB timeDB(TIMEZONE_DB_API_KEY);
 DisplayManager displayManager(matrix);
@@ -25,6 +30,37 @@ TimeManager timeManager(timeDB, displayManager);
 MQTTManager mqttManager(displayManager, timeManager);
 OTAManager otaManager(displayManager);
 WebOTAManager webOtaManager(displayManager);
+
+// Keep background services alive during otherwise-blocking display operations
+// (see BackgroundService.h). Feeding the watchdog is always safe; the network
+// services are only pumped once setup() has started them.
+void serviceBackground()
+{
+  ESP.wdtFeed();
+  if (!servicesReady)
+  {
+    return;
+  }
+  otaManager.loop();
+  webOtaManager.loop();
+  mqttManager.keepAlive();
+}
+
+void serviceDelay(unsigned long ms)
+{
+  unsigned long start = millis();
+  while (true)
+  {
+    serviceBackground();
+    unsigned long elapsed = millis() - start;
+    if (elapsed >= ms)
+    {
+      break;
+    }
+    unsigned long remaining = ms - elapsed;
+    delay(remaining > 15 ? 15 : remaining);
+  }
+}
 
 void setup()
 {
@@ -57,6 +93,10 @@ void setup()
   // Initialize MQTT last. Connection is established lazily in loop()
   // (see mqttManager.loop()), so this call never blocks startup.
   mqttManager.initialize();
+
+  // All network services are up: allow serviceBackground() to pump them during
+  // long display operations from now on.
+  servicesReady = true;
 }
 
 void loop()


### PR DESCRIPTION
## Notifications
- Replaced the on/off content blink with a quick brightness **fade out/in** (`DisplayManager::fadeMessage`, 25 ms/step) before holding the static text. Faster than the old boot fade, no trailing pause. `flash`/`flash_count` now describe fade pulses.

## Refactors / fixes
- **Brightness guard before first time sync** (`currentAutoBrightness`): display no longer drops into night mode at boot when `hour()` reads 00:00.
- **Unified WiFi portal SSID** into `WIFI_PORTAL_AP_NAME` (`Settings.h`); `WiFiSetup` no longer hardcodes it.
- **Web UI MQTT topic list** rebuilt from the actual `MQTT_TOPIC_*` constants (was stale/missing topics).
- **Discovery refactor**: extracted `publishDiscovery` / `getDeviceId` / `buildDeviceInfo`; `sendDiscoveryConfig` shrinks from ~130 lines of hand-escaped JSON to 8 concise calls.
- **Cooperative servicing**: new `BackgroundService` (`serviceBackground`/`serviceDelay`) + `MQTTManager::keepAlive` keep OTA/MQTT/web alive during scrolls, animations and static holds. A `servicesReady` flag keeps boot-time scrolls safe.
- **Dead code removed**: `TimeDB` day/month/ampm decls + `localMillisAtUpdate`, `TimeManager::timeoutCount`, `MQTT_MAX_RECONNECT_ATTEMPTS`.

Builds clean (RAM 52.8%, Flash 45.3%) and flashed/verified on the device over USB.