### PR TITLE
fix(wifi): config portal timeout + OTA upload env

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -26,3 +26,10 @@ lib_deps =
 	ArduinoOTA
 	ESP8266WebServer
 	ESP8266HTTPUpdateServer
+
+; Over-the-air upload target. Build/upload with: pio run -e d1_mini_ota -t upload
+[env:d1_mini_ota]
+extends = env:d1_mini
+upload_protocol = espota
+upload_port = ZegarTV.local
+upload_flags = --auth=mqtt-clock-ota

--- a/src/WiFiSetup.cpp
+++ b/src/WiFiSetup.cpp
@@ -15,12 +15,17 @@ void WiFiSetup::initialize()
   WiFiManager wifiManager;
   wifiManager.setAPCallback(configModeCallback);
 
+  // Give the config portal a generous timeout so a transient router outage
+  // doesn't trap the device on the "WiFi" portal screen forever. When it
+  // expires, autoConnect() returns false and we reboot to retry the router.
+  // Kept long (10 min) so an in-progress manual setup isn't cut short.
+  wifiManager.setConfigPortalTimeout(WIFI_CONFIG_PORTAL_TIMEOUT_SECONDS);
+
   String hostname = "Zegar TV";
   if (!wifiManager.autoConnect(hostname.c_str()))
   {
-    Serial.println("Failed to connect to WiFi, restarting...");
+    Serial.println("Config portal timed out, rebooting to retry WiFi...");
     delay(3000);
-    WiFi.disconnect(true);
     ESP.reset();
     delay(5000);
   }

--- a/src/WiFiSetup.h
+++ b/src/WiFiSetup.h
@@ -6,6 +6,7 @@
 // WiFi reliability constants
 const int WIFI_MAX_RECONNECT_ATTEMPTS = 10;     // Max reconnect attempts before reboot
 const unsigned long WIFI_RECONNECT_DELAY = 500; // Delay between reconnect attempts (ms)
+const int WIFI_CONFIG_PORTAL_TIMEOUT_SECONDS = 600; // Portal timeout before reboot/retry (10 min)
 
 class WiFiSetup
 {


### PR DESCRIPTION
## Problem

The router is scheduled to restart every Monday at 4am. After one such restart the clock got stuck displaying **"WiFi"** and never recovered on its own.

**Root cause:** `wifiManager.autoConnect()` was called with no config portal timeout. Without a timeout, autoConnect blocks forever in the AP config portal (the "WiFi" screen) and **never returns `false`** — so the existing `WiFi.disconnect(true); ESP.reset();` fallback was effectively dead code (the upstream author even left a `"This should never happen"` note). A transient router outage at boot therefore traps the device on the portal indefinitely instead of retrying the router.

## Changes

- **`WiFiSetup`**: add `setConfigPortalTimeout(600)` (10 min). When the portal expires, `autoConnect()` returns `false` and the device reboots to retry the router — so a router restart now self-heals. Timeout kept long (10 min) so an in-progress manual setup isn't cut short.
- Drop the pointless `WiFi.disconnect(true)` immediately before `ESP.reset()` (a reset re-inits everything anyway; on ESP8266 the flag only toggles the radio, not stored credentials).
- **`platformio.ini`**: add a `d1_mini_ota` environment for over-the-air uploads (`pio run -e d1_mini_ota -t upload`).

## Testing

- Firmware builds cleanly (Flash 45.2%, RAM 52.9%).
- Flashed to the live device over OTA (Result: OK); it rebooted and rejoined the network successfully.